### PR TITLE
Fix repository sharing and compile issue

### DIFF
--- a/app/src/main/java/com/example/app/ServiceLocator.kt
+++ b/app/src/main/java/com/example/app/ServiceLocator.kt
@@ -1,0 +1,11 @@
+package com.example.app
+
+import com.example.app.data.repository.InMemoryRecipeRepository
+import com.example.app.domain.repository.RecipeRepository
+
+/**
+ * Simple service locator providing shared dependencies.
+ */
+object ServiceLocator {
+    val recipeRepository: RecipeRepository by lazy { InMemoryRecipeRepository() }
+}

--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
@@ -6,7 +6,7 @@ import android.widget.EditText
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.example.app.R
-import com.example.app.data.repository.InMemoryRecipeRepository
+import com.example.app.ServiceLocator
 import com.example.app.domain.model.Ingredient
 import com.example.app.domain.model.Recipe
 import com.example.app.domain.model.Step
@@ -21,8 +21,7 @@ class AddRecipeActivity : AppCompatActivity() {
     private val viewModel: AddRecipeViewModel by viewModels {
         object : androidx.lifecycle.ViewModelProvider.Factory {
             override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-                val repo = InMemoryRecipeRepository()
-                val useCase = AddRecipeUseCase(repo)
+                val useCase = AddRecipeUseCase(ServiceLocator.recipeRepository)
                 @Suppress("UNCHECKED_CAST")
                 return AddRecipeViewModel(useCase) as T
             }

--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeViewModel.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeViewModel.kt
@@ -7,9 +7,9 @@ import com.example.app.domain.usecase.AddRecipeUseCase
 /**
  * ViewModel for creating a new recipe.
  */
-class AddRecipeViewModel(private val addRecipe: AddRecipeUseCase) : ViewModel() {
+class AddRecipeViewModel(private val addRecipeUseCase: AddRecipeUseCase) : ViewModel() {
 
     fun addRecipe(recipe: Recipe) {
-        addRecipe.invoke(recipe)
+        addRecipeUseCase.invoke(recipe)
     }
 }

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -7,7 +7,7 @@ import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.example.app.R
-import com.example.app.data.repository.InMemoryRecipeRepository
+import com.example.app.ServiceLocator
 import com.example.app.domain.usecase.GetRecipeUseCase
 
 /**
@@ -18,8 +18,7 @@ class RecipeDetailActivity : AppCompatActivity() {
     private val viewModel: RecipeDetailViewModel by viewModels {
         object : androidx.lifecycle.ViewModelProvider.Factory {
             override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-                val repo = InMemoryRecipeRepository()
-                val useCase = GetRecipeUseCase(repo)
+                val useCase = GetRecipeUseCase(ServiceLocator.recipeRepository)
                 @Suppress("UNCHECKED_CAST")
                 return RecipeDetailViewModel(useCase) as T
             }

--- a/app/src/main/java/com/example/app/presentation/list/MainActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/list/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.app.R
-import com.example.app.data.repository.InMemoryRecipeRepository
+import com.example.app.ServiceLocator
 import com.example.app.domain.usecase.GetRecipesUseCase
 import com.example.app.presentation.detail.RecipeDetailActivity
 
@@ -19,8 +19,7 @@ class MainActivity : AppCompatActivity() {
     private val viewModel: MainViewModel by viewModels {
         object : androidx.lifecycle.ViewModelProvider.Factory {
             override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-                val repo = InMemoryRecipeRepository()
-                val useCase = GetRecipesUseCase(repo)
+                val useCase = GetRecipesUseCase(ServiceLocator.recipeRepository)
                 @Suppress("UNCHECKED_CAST")
                 return MainViewModel(useCase) as T
             }


### PR DESCRIPTION
## Summary
- add ServiceLocator singleton to share `RecipeRepository`
- use the service locator in activities instead of creating new repositories
- rename property in `AddRecipeViewModel` to avoid function name conflict

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6862d34748d88330a97c94c2ed086104