### PR TITLE
Fix namespace configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    // Required as of AGP 8 to define the package namespace
+    namespace = "com.example.app"
     compileSdk = 34
 
     defaultConfig {


### PR DESCRIPTION
## Summary
- add required namespace to the `app` module

## Testing
- `./gradlew assemble` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6862d45fea4883309af58c5e6cd2a9f8