### PR TITLE
Fix: enable AndroidX

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,8 @@ org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
 
+# Enable AndroidX support libraries
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true
+


### PR DESCRIPTION
## Summary
- enable AndroidX support in `gradle.properties`

## Testing
- `./gradlew assemble` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6862da7b0fb0833087fccc81e699a2eb