### PR TITLE
Fix manifest package and update minSdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Android 16 App
+# Android 19 App
 
-This repository contains a minimal Android application that targets API 16.
+This repository contains a minimal Android application that targets API 19.
 
 ## Modules
 - `app`: main application module

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.app"
-        minSdk = 16
+        minSdk = 19
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- remove `package` attribute from `AndroidManifest.xml`
- bump `minSdk` to 19 in app module
- update README to reference API 19

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6862db7e4bd08330a627f41b8fbe2935