### PR TITLE
Add android:exported attribute

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,9 @@
 
         <activity android:name="com.example.app.presentation.add.AddRecipeActivity" />
         <activity android:name="com.example.app.presentation.detail.RecipeDetailActivity" />
-        <activity android:name="com.example.app.presentation.list.MainActivity">
+        <activity
+            android:name="com.example.app.presentation.list.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- fix build issue on API 31+ by specifying `android:exported` for `MainActivity`

## Testing
- `./gradlew assemble` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6862dc2890d08330b1a26bd1ccde80f9