### PR TITLE
Fix missing viewModels reference

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
+    // Needed for the viewModels activity-ktx extension
+    implementation("androidx.activity:activity-ktx:1.9.0")
+
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.1")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.1")
 


### PR DESCRIPTION
## Summary
- add androidx.activity dependency

## Testing
- `gradle wrapper` *(fails: Plugin was not found because network is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd56c3c48330b3175b1d97c15e61