### PR TITLE
Add troubleshooting guidance for missing imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ This repository contains a minimal Android application that targets API 19.
 Use the Android Gradle Plugin 8.4.0 with Kotlin 1.9.21.
 
 Run `gradle wrapper` to generate a local wrapper (requires network access) and then `./gradlew assemble`.
+
+### Troubleshooting missing imports
+The sample relies on the AndroidX *activity-ktx* artifact for the
+`viewModels` extension. Ensure your `build.gradle.kts` contains:
+
+```kotlin
+implementation("androidx.activity:activity-ktx:1.9.0")
+```
+
+The `R` class is generated from resources when the module builds
+successfully. Verify that the package namespace in `android` block is set
+to `"com.example.app"` so that the `import com.example.app.R` statement
+resolves correctly.


### PR DESCRIPTION
## Summary
- document how to resolve `viewModels` and `R` imports in README

## Testing
- `gradle wrapper --stacktrace --console=plain` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862deb3e2108330b7e4f25046d2e0c2