### PR TITLE
Fix LiveData mutation in RecipeDetailActivity

### DIFF
--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -60,13 +60,7 @@ class RecipeDetailActivity : AppCompatActivity() {
         findViewById<TextView>(R.id.update_servings).setOnClickListener {
             val servingsInput = findViewById<EditText>(R.id.servings_input)
             val newServings = servingsInput.text.toString().toIntOrNull() ?: return@setOnClickListener
-            viewModel.recipe.value?.let { current ->
-                viewModel.loadRecipe(current.id)
-                viewModel.recipe.value?.let {
-                    val updated = it.copy(servings = newServings)
-                    viewModel.recipe.value = updated
-                }
-            }
+            viewModel.updateServings(newServings)
         }
 
         viewModel.loadRecipe(id)

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailViewModel.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailViewModel.kt
@@ -19,4 +19,11 @@ class RecipeDetailViewModel(
     fun loadRecipe(id: Int) {
         _recipe.value = getRecipe(id)
     }
+
+    /**
+     * Updates the current recipe with a new servings count.
+     */
+    fun updateServings(newServings: Int) {
+        _recipe.value = _recipe.value?.copy(servings = newServings)
+    }
 }


### PR DESCRIPTION
## Summary
- add an updateServings method in RecipeDetailViewModel to modify MutableLiveData
- call the new method from RecipeDetailActivity

## Testing
- `gradle wrapper` *(fails: Plugin not found)*


------
https://chatgpt.com/codex/tasks/task_e_6862e10c7f088330ada87614eb7e5c4f