### PR TITLE
Add persistent recipes and editing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name="com.example.app.CookbookApp"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/example/app/CookbookApp.kt
+++ b/app/src/main/java/com/example/app/CookbookApp.kt
@@ -1,0 +1,10 @@
+package com.example.app
+
+import android.app.Application
+
+class CookbookApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        ServiceLocator.init(this)
+    }
+}

--- a/app/src/main/java/com/example/app/ServiceLocator.kt
+++ b/app/src/main/java/com/example/app/ServiceLocator.kt
@@ -1,11 +1,17 @@
 package com.example.app
 
-import com.example.app.data.repository.InMemoryRecipeRepository
+import android.content.Context
+import com.example.app.data.repository.PersistentRecipeRepository
 import com.example.app.domain.repository.RecipeRepository
 
 /**
  * Simple service locator providing shared dependencies.
  */
 object ServiceLocator {
-    val recipeRepository: RecipeRepository by lazy { InMemoryRecipeRepository() }
+    private lateinit var applicationContext: Context
+    val recipeRepository: RecipeRepository by lazy { PersistentRecipeRepository(applicationContext) }
+
+    fun init(context: Context) {
+        applicationContext = context.applicationContext
+    }
 }

--- a/app/src/main/java/com/example/app/data/repository/InMemoryRecipeRepository.kt
+++ b/app/src/main/java/com/example/app/data/repository/InMemoryRecipeRepository.kt
@@ -13,7 +13,7 @@ class InMemoryRecipeRepository : RecipeRepository {
     private val recipes = mutableListOf<Recipe>()
 
     init {
-        // Add sample recipe on startup
+        // Add sample recipes on startup
         val flour = Ingredient("Flour", "g", 100.0)
         val egg = Ingredient("Egg", "pcs", 1.0)
         val milk = Ingredient("Milk", "ml", 150.0)
@@ -41,6 +41,34 @@ class InMemoryRecipeRepository : RecipeRepository {
             ingredients = listOf(flour, egg, milk),
             steps = steps
         )
+
+        // Second recipe
+        val pasta = Ingredient("Pasta", "g", 100.0)
+        val tomato = Ingredient("Tomato", "pcs", 2.0)
+        val cheese = Ingredient("Cheese", "g", 50.0)
+
+        val pastaSteps = listOf(
+            Step(
+                "Cook pasta",
+                listOf(StepIngredient(pasta, 100.0))
+            ),
+            Step(
+                "Add sauce",
+                listOf(
+                    StepIngredient(tomato, 2.0),
+                    StepIngredient(cheese, 50.0)
+                )
+            )
+        )
+
+        recipes += Recipe(
+            id = 2,
+            name = "Pasta",
+            imageRes = android.R.drawable.ic_menu_gallery,
+            servings = 1,
+            ingredients = listOf(pasta, tomato, cheese),
+            steps = pastaSteps
+        )
     }
 
     override fun getRecipes(): List<Recipe> = recipes
@@ -49,5 +77,12 @@ class InMemoryRecipeRepository : RecipeRepository {
 
     override fun addRecipe(recipe: Recipe) {
         recipes += recipe.copy(id = (recipes.maxOfOrNull { it.id } ?: 0) + 1)
+    }
+
+    override fun updateRecipe(recipe: Recipe) {
+        val index = recipes.indexOfFirst { it.id == recipe.id }
+        if (index != -1) {
+            recipes[index] = recipe
+        }
     }
 }

--- a/app/src/main/java/com/example/app/data/repository/PersistentRecipeRepository.kt
+++ b/app/src/main/java/com/example/app/data/repository/PersistentRecipeRepository.kt
@@ -1,0 +1,201 @@
+package com.example.app.data.repository
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import com.example.app.domain.model.Ingredient
+import com.example.app.domain.model.Recipe
+import com.example.app.domain.model.Step
+import com.example.app.domain.model.StepIngredient
+import com.example.app.domain.repository.RecipeRepository
+
+/**
+ * Simple file based implementation of [RecipeRepository]. Recipes are stored as
+ * JSON in the app's private storage.
+ */
+class PersistentRecipeRepository(private val context: Context) : RecipeRepository {
+
+    private val fileName = "recipes.json"
+    private val recipes = mutableListOf<Recipe>()
+
+    init {
+        load()
+        if (recipes.isEmpty()) {
+            addSampleRecipes()
+            save()
+        }
+    }
+
+    override fun getRecipes(): List<Recipe> = recipes
+
+    override fun getRecipe(id: Int): Recipe? = recipes.find { it.id == id }
+
+    override fun addRecipe(recipe: Recipe) {
+        val newId = (recipes.maxOfOrNull { it.id } ?: 0) + 1
+        recipes += recipe.copy(id = newId)
+        save()
+    }
+
+    override fun updateRecipe(recipe: Recipe) {
+        val index = recipes.indexOfFirst { it.id == recipe.id }
+        if (index != -1) {
+            recipes[index] = recipe
+            save()
+        }
+    }
+
+    private fun load() {
+        try {
+            val jsonStr = context.openFileInput(fileName).bufferedReader().use { it.readText() }
+            val array = JSONArray(jsonStr)
+            for (i in 0 until array.length()) {
+                val obj = array.getJSONObject(i)
+                recipes += obj.toRecipe()
+            }
+        } catch (_: Exception) {
+            // ignore, start with empty list
+        }
+    }
+
+    private fun save() {
+        val array = JSONArray()
+        recipes.forEach { array.put(it.toJson()) }
+        context.openFileOutput(fileName, Context.MODE_PRIVATE).use { it.write(array.toString().toByteArray()) }
+    }
+}
+
+private fun JSONObject.toIngredient(): Ingredient =
+    Ingredient(getString("name"), getString("unit"), getDouble("quantityPerServing"))
+
+private fun JSONObject.toStep(ingredients: Map<Int, Ingredient>): Step {
+    val desc = getString("description")
+    val ingArr = getJSONArray("ingredients")
+    val stepIngredients = mutableListOf<StepIngredient>()
+    for (i in 0 until ingArr.length()) {
+        val o = ingArr.getJSONObject(i)
+        val ingId = o.getInt("ingredientIndex")
+        val ingredient = ingredients[ingId] ?: continue
+        stepIngredients += StepIngredient(ingredient, o.getDouble("amountPerServing"))
+    }
+    return Step(desc, stepIngredients)
+}
+
+private fun JSONArray.toIngredientList(): List<Ingredient> {
+    val list = mutableListOf<Ingredient>()
+    for (i in 0 until length()) {
+        list += getJSONObject(i).toIngredient()
+    }
+    return list
+}
+
+private fun JSONArray.toStepList(ingredients: List<Ingredient>): List<Step> {
+    val list = mutableListOf<Step>()
+    val ingMap = ingredients.withIndex().associate { it.index to it.value }
+    for (i in 0 until length()) {
+        list += getJSONObject(i).toStep(ingMap)
+    }
+    return list
+}
+
+private fun Recipe.toJson(): JSONObject {
+    val obj = JSONObject()
+    obj.put("id", id)
+    obj.put("name", name)
+    obj.put("imageRes", imageRes)
+    obj.put("servings", servings)
+
+    val ingredientsArray = JSONArray()
+    ingredients.forEach { ing ->
+        val o = JSONObject()
+        o.put("name", ing.name)
+        o.put("unit", ing.unit)
+        o.put("quantityPerServing", ing.quantityPerServing)
+        ingredientsArray.put(o)
+    }
+    obj.put("ingredients", ingredientsArray)
+
+    val stepsArray = JSONArray()
+    steps.forEach { step ->
+        val stepObj = JSONObject()
+        stepObj.put("description", step.description)
+        val ingArr = JSONArray()
+        step.ingredients.forEach { si ->
+            val ingIndex = ingredients.indexOfFirst { it == si.ingredient }
+            val siObj = JSONObject()
+            siObj.put("ingredientIndex", ingIndex)
+            siObj.put("amountPerServing", si.amountPerServing)
+            ingArr.put(siObj)
+        }
+        stepObj.put("ingredients", ingArr)
+        stepsArray.put(stepObj)
+    }
+    obj.put("steps", stepsArray)
+
+    return obj
+}
+
+private fun JSONObject.toRecipe(): Recipe {
+    val ingredients = getJSONArray("ingredients").toIngredientList()
+    val steps = getJSONArray("steps").toStepList(ingredients)
+
+    return Recipe(
+        id = getInt("id"),
+        name = getString("name"),
+        imageRes = getInt("imageRes"),
+        servings = getInt("servings"),
+        ingredients = ingredients,
+        steps = steps
+    )
+}
+
+private fun PersistentRecipeRepository.addSampleRecipes() {
+    val flour = Ingredient("Flour", "g", 100.0)
+    val egg = Ingredient("Egg", "pcs", 1.0)
+    val milk = Ingredient("Milk", "ml", 150.0)
+
+    val pancakeSteps = listOf(
+        Step(
+            "Mix ingredients",
+            listOf(
+                StepIngredient(flour, 100.0),
+                StepIngredient(egg, 1.0),
+                StepIngredient(milk, 150.0)
+            )
+        ),
+        Step("Bake in pan", emptyList())
+    )
+
+    recipes += Recipe(
+        id = 1,
+        name = "Pancakes",
+        imageRes = android.R.drawable.ic_menu_gallery,
+        servings = 2,
+        ingredients = listOf(flour, egg, milk),
+        steps = pancakeSteps
+    )
+
+    val pasta = Ingredient("Pasta", "g", 100.0)
+    val tomato = Ingredient("Tomato", "pcs", 2.0)
+    val cheese = Ingredient("Cheese", "g", 50.0)
+
+    val pastaSteps = listOf(
+        Step("Cook pasta", listOf(StepIngredient(pasta, 100.0))),
+        Step(
+            "Add sauce",
+            listOf(
+                StepIngredient(tomato, 2.0),
+                StepIngredient(cheese, 50.0)
+            )
+        )
+    )
+
+    recipes += Recipe(
+        id = 2,
+        name = "Pasta",
+        imageRes = android.R.drawable.ic_menu_gallery,
+        servings = 1,
+        ingredients = listOf(pasta, tomato, cheese),
+        steps = pastaSteps
+    )
+}
+

--- a/app/src/main/java/com/example/app/domain/repository/RecipeRepository.kt
+++ b/app/src/main/java/com/example/app/domain/repository/RecipeRepository.kt
@@ -9,4 +9,5 @@ interface RecipeRepository {
     fun getRecipes(): List<Recipe>
     fun getRecipe(id: Int): Recipe?
     fun addRecipe(recipe: Recipe)
+    fun updateRecipe(recipe: Recipe)
 }

--- a/app/src/main/java/com/example/app/domain/usecase/UpdateRecipeUseCase.kt
+++ b/app/src/main/java/com/example/app/domain/usecase/UpdateRecipeUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.app.domain.usecase
+
+import com.example.app.domain.model.Recipe
+import com.example.app.domain.repository.RecipeRepository
+
+/**
+ * Updates an existing recipe.
+ */
+class UpdateRecipeUseCase(private val repository: RecipeRepository) {
+    operator fun invoke(recipe: Recipe) = repository.updateRecipe(recipe)
+}

--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
@@ -1,8 +1,7 @@
 package com.example.app.presentation.add
 
 import android.os.Bundle
-import android.widget.Button
-import android.widget.EditText
+import android.widget.*
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.example.app.R
@@ -10,20 +9,26 @@ import com.example.app.ServiceLocator
 import com.example.app.domain.model.Ingredient
 import com.example.app.domain.model.Recipe
 import com.example.app.domain.model.Step
-import com.example.app.domain.model.StepIngredient
 import com.example.app.domain.usecase.AddRecipeUseCase
+import com.example.app.domain.usecase.GetRecipeUseCase
+import com.example.app.domain.usecase.UpdateRecipeUseCase
 
 /**
  * Minimal screen to add new recipes.
  */
 class AddRecipeActivity : AppCompatActivity() {
 
+    companion object {
+        const val EXTRA_RECIPE_ID = "recipe_id"
+    }
+
     private val viewModel: AddRecipeViewModel by viewModels {
         object : androidx.lifecycle.ViewModelProvider.Factory {
             override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-                val useCase = AddRecipeUseCase(ServiceLocator.recipeRepository)
+                val add = AddRecipeUseCase(ServiceLocator.recipeRepository)
+                val update = UpdateRecipeUseCase(ServiceLocator.recipeRepository)
                 @Suppress("UNCHECKED_CAST")
-                return AddRecipeViewModel(useCase) as T
+                return AddRecipeViewModel(add, update) as T
             }
         }
     }
@@ -32,20 +37,47 @@ class AddRecipeActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_add_recipe)
 
+        val servingsSpinner = findViewById<Spinner>(R.id.spinner_servings)
+        servingsSpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, (1..10).toList())
+
+        val recipeId = intent.getIntExtra(EXTRA_RECIPE_ID, -1)
+        val existingRecipe = if (recipeId != -1) GetRecipeUseCase(ServiceLocator.recipeRepository).invoke(recipeId) else null
+
+        existingRecipe?.let { recipe ->
+            findViewById<EditText>(R.id.input_name).setText(recipe.name)
+            servingsSpinner.setSelection(recipe.servings - 1)
+            val ingredientsText = recipe.ingredients.joinToString("\n") { "${it.name},${it.quantityPerServing},${it.unit}" }
+            findViewById<EditText>(R.id.input_ingredients).setText(ingredientsText)
+            val stepsText = recipe.steps.joinToString("\n") { it.description }
+            findViewById<EditText>(R.id.input_steps).setText(stepsText)
+        }
+
         findViewById<Button>(R.id.save_recipe).setOnClickListener {
             val name = findViewById<EditText>(R.id.input_name).text.toString()
-            val servings = findViewById<EditText>(R.id.input_servings).text.toString().toIntOrNull() ?: 1
+            val servings = servingsSpinner.selectedItem as Int
 
-            // For simplicity we only support one ingredient and one step via text inputs
-            val ingredientName = findViewById<EditText>(R.id.input_ingredient).text.toString()
-            val quantity = findViewById<EditText>(R.id.input_quantity).text.toString().toDoubleOrNull() ?: 0.0
-            val unit = findViewById<EditText>(R.id.input_unit).text.toString()
+            val ingredientsLines = findViewById<EditText>(R.id.input_ingredients).text.toString()
+                .split('\n')
+                .filter { it.isNotBlank() }
+            val ingredients = ingredientsLines.mapNotNull { line ->
+                val parts = line.split(',')
+                if (parts.size == 3) {
+                    val quantity = parts[1].toDoubleOrNull() ?: return@mapNotNull null
+                    Ingredient(parts[0].trim(), parts[2].trim(), quantity)
+                } else null
+            }
 
-            val ingredient = Ingredient(ingredientName, unit, quantity)
-            val step = Step("Mix ingredients", listOf(StepIngredient(ingredient, quantity)))
+            val stepsLines = findViewById<EditText>(R.id.input_steps).text.toString()
+                .split('\n')
+                .filter { it.isNotBlank() }
+            val steps = stepsLines.map { Step(it, emptyList()) }
 
-            val recipe = Recipe(0, name, android.R.drawable.ic_menu_gallery, servings, listOf(ingredient), listOf(step))
-            viewModel.addRecipe(recipe)
+            val recipe = Recipe(recipeId.takeIf { it != -1 } ?: 0, name, android.R.drawable.ic_menu_gallery, servings, ingredients, steps)
+            if (existingRecipe != null) {
+                viewModel.updateRecipe(recipe)
+            } else {
+                viewModel.addRecipe(recipe)
+            }
             finish()
         }
 

--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeViewModel.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeViewModel.kt
@@ -3,13 +3,21 @@ package com.example.app.presentation.add
 import androidx.lifecycle.ViewModel
 import com.example.app.domain.model.Recipe
 import com.example.app.domain.usecase.AddRecipeUseCase
+import com.example.app.domain.usecase.UpdateRecipeUseCase
 
 /**
  * ViewModel for creating a new recipe.
  */
-class AddRecipeViewModel(private val addRecipeUseCase: AddRecipeUseCase) : ViewModel() {
+class AddRecipeViewModel(
+    private val addRecipeUseCase: AddRecipeUseCase,
+    private val updateRecipeUseCase: UpdateRecipeUseCase
+) : ViewModel() {
 
     fun addRecipe(recipe: Recipe) {
         addRecipeUseCase.invoke(recipe)
+    }
+
+    fun updateRecipe(recipe: Recipe) {
+        updateRecipeUseCase.invoke(recipe)
     }
 }

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -5,11 +5,14 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.content.Intent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.example.app.R
 import com.example.app.ServiceLocator
 import com.example.app.domain.usecase.GetRecipeUseCase
+import com.example.app.presentation.add.AddRecipeActivity
+import com.example.app.domain.model.Step
 
 /**
  * Displays details for a selected recipe.
@@ -47,14 +50,8 @@ class RecipeDetailActivity : AppCompatActivity() {
             stepLayout.removeAllViews()
             recipe.steps.forEach { step ->
                 val stepTv = TextView(this)
-                stepTv.text = step.description
+                stepTv.text = formatStep(step, recipe.servings)
                 stepLayout.addView(stepTv)
-                step.ingredients.forEach { si ->
-                    val ingTv = TextView(this)
-                    val amount = si.amountPerServing * recipe.servings
-                    ingTv.text = "- ${si.ingredient.name}: $amount ${si.ingredient.unit}"
-                    stepLayout.addView(ingTv)
-                }
             }
         }
 
@@ -64,9 +61,25 @@ class RecipeDetailActivity : AppCompatActivity() {
             viewModel.updateServings(newServings)
         }
 
+        findViewById<Button>(R.id.edit_button).setOnClickListener {
+            val intent = Intent(this, AddRecipeActivity::class.java)
+            intent.putExtra(AddRecipeActivity.EXTRA_RECIPE_ID, id)
+            startActivity(intent)
+        }
+
         findViewById<Button>(R.id.back_button).setOnClickListener { finish() }
 
         viewModel.loadRecipe(id)
+    }
+
+    private fun formatStep(step: Step, servings: Int): String {
+        var text = step.description
+        step.ingredients.forEach { si ->
+            val token = "{{${si.ingredient.name}}}"
+            val amount = si.amountPerServing * servings
+            text = text.replace(token, "$amount ${si.ingredient.unit}")
+        }
+        return text
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_add_recipe.xml
+++ b/app/src/main/res/layout/activity_add_recipe.xml
@@ -15,37 +15,30 @@
             android:layout_height="wrap_content"
             android:hint="Name" />
 
-        <EditText
-            android:id="@+id/input_servings"
+        <Spinner
+            android:id="@+id/spinner_servings"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Servings"
-            android:inputType="number" />
+            android:layout_height="wrap_content" />
 
         <EditText
-            android:id="@+id/input_ingredient"
+            android:id="@+id/input_ingredients"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Ingredient" />
+            android:hint="Ingredients (name,quantity,unit per line)"
+            android:inputType="textMultiLine" />
 
         <EditText
-            android:id="@+id/input_quantity"
+            android:id="@+id/input_steps"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Quantity"
-            android:inputType="numberDecimal" />
-
-        <EditText
-            android:id="@+id/input_unit"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Unit" />
+            android:hint="Steps (one per line)"
+            android:inputType="textMultiLine" />
 
         <Button
             android:id="@+id/save_recipe"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Save" />
+            android:text="@string/save" />
 
         <Button
             android:id="@+id/back_button"

--- a/app/src/main/res/layout/activity_recipe_detail.xml
+++ b/app/src/main/res/layout/activity_recipe_detail.xml
@@ -48,6 +48,12 @@
             android:paddingTop="16dp" />
 
         <Button
+            android:id="@+id/edit_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Edit" />
+
+        <Button
             android:id="@+id/back_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- persist recipes using a JSON file via `PersistentRecipeRepository`
- set up `ServiceLocator` to use persistent repository initialized in `CookbookApp`
- allow adding/editing recipes with a servings spinner and multiline inputs
- show a button in detail view to edit a recipe and format steps
- include two sample recipes when none are saved

## Testing
- `./gradlew assemble` *(fails: Unable to access gradle wrapper jar)*

------
https://chatgpt.com/codex/tasks/task_e_686c1b19d668833083f292a612556d52