### PR TITLE
Enable recipe deletion and fix repository

### DIFF
--- a/app/src/main/java/com/example/app/data/repository/InMemoryRecipeRepository.kt
+++ b/app/src/main/java/com/example/app/data/repository/InMemoryRecipeRepository.kt
@@ -85,4 +85,8 @@ class InMemoryRecipeRepository : RecipeRepository {
             recipes[index] = recipe
         }
     }
+
+    override fun deleteRecipe(id: Int) {
+        recipes.removeAll { it.id == id }
+    }
 }

--- a/app/src/main/java/com/example/app/data/repository/PersistentRecipeRepository.kt
+++ b/app/src/main/java/com/example/app/data/repository/PersistentRecipeRepository.kt
@@ -44,6 +44,13 @@ class PersistentRecipeRepository(private val context: Context) : RecipeRepositor
         }
     }
 
+    override fun deleteRecipe(id: Int) {
+        val changed = recipes.removeAll { it.id == id }
+        if (changed) {
+            save()
+        }
+    }
+
     private fun load() {
         try {
             val jsonStr = context.openFileInput(fileName).bufferedReader().use { it.readText() }
@@ -61,6 +68,56 @@ class PersistentRecipeRepository(private val context: Context) : RecipeRepositor
         val array = JSONArray()
         recipes.forEach { array.put(it.toJson()) }
         context.openFileOutput(fileName, Context.MODE_PRIVATE).use { it.write(array.toString().toByteArray()) }
+    }
+    private fun addSampleRecipes() {
+        val flour = Ingredient("Flour", "g", 100.0)
+        val egg = Ingredient("Egg", "pcs", 1.0)
+        val milk = Ingredient("Milk", "ml", 150.0)
+
+        val pancakeSteps = listOf(
+            Step(
+                "Mix ingredients",
+                listOf(
+                    StepIngredient(flour, 100.0),
+                    StepIngredient(egg, 1.0),
+                    StepIngredient(milk, 150.0)
+                )
+            ),
+            Step("Bake in pan", emptyList())
+        )
+
+        recipes += Recipe(
+            id = 1,
+            name = "Pancakes",
+            imageRes = android.R.drawable.ic_menu_gallery,
+            servings = 2,
+            ingredients = listOf(flour, egg, milk),
+            steps = pancakeSteps
+        )
+
+        val pasta = Ingredient("Pasta", "g", 100.0)
+        val tomato = Ingredient("Tomato", "pcs", 2.0)
+        val cheese = Ingredient("Cheese", "g", 50.0)
+
+        val pastaSteps = listOf(
+            Step("Cook pasta", listOf(StepIngredient(pasta, 100.0))),
+            Step(
+                "Add sauce",
+                listOf(
+                    StepIngredient(tomato, 2.0),
+                    StepIngredient(cheese, 50.0)
+                )
+            )
+        )
+
+        recipes += Recipe(
+            id = 2,
+            name = "Pasta",
+            imageRes = android.R.drawable.ic_menu_gallery,
+            servings = 1,
+            ingredients = listOf(pasta, tomato, cheese),
+            steps = pastaSteps
+        )
     }
 }
 
@@ -148,54 +205,4 @@ private fun JSONObject.toRecipe(): Recipe {
     )
 }
 
-private fun PersistentRecipeRepository.addSampleRecipes() {
-    val flour = Ingredient("Flour", "g", 100.0)
-    val egg = Ingredient("Egg", "pcs", 1.0)
-    val milk = Ingredient("Milk", "ml", 150.0)
-
-    val pancakeSteps = listOf(
-        Step(
-            "Mix ingredients",
-            listOf(
-                StepIngredient(flour, 100.0),
-                StepIngredient(egg, 1.0),
-                StepIngredient(milk, 150.0)
-            )
-        ),
-        Step("Bake in pan", emptyList())
-    )
-
-    recipes += Recipe(
-        id = 1,
-        name = "Pancakes",
-        imageRes = android.R.drawable.ic_menu_gallery,
-        servings = 2,
-        ingredients = listOf(flour, egg, milk),
-        steps = pancakeSteps
-    )
-
-    val pasta = Ingredient("Pasta", "g", 100.0)
-    val tomato = Ingredient("Tomato", "pcs", 2.0)
-    val cheese = Ingredient("Cheese", "g", 50.0)
-
-    val pastaSteps = listOf(
-        Step("Cook pasta", listOf(StepIngredient(pasta, 100.0))),
-        Step(
-            "Add sauce",
-            listOf(
-                StepIngredient(tomato, 2.0),
-                StepIngredient(cheese, 50.0)
-            )
-        )
-    )
-
-    recipes += Recipe(
-        id = 2,
-        name = "Pasta",
-        imageRes = android.R.drawable.ic_menu_gallery,
-        servings = 1,
-        ingredients = listOf(pasta, tomato, cheese),
-        steps = pastaSteps
-    )
-}
 

--- a/app/src/main/java/com/example/app/domain/repository/RecipeRepository.kt
+++ b/app/src/main/java/com/example/app/domain/repository/RecipeRepository.kt
@@ -10,4 +10,5 @@ interface RecipeRepository {
     fun getRecipe(id: Int): Recipe?
     fun addRecipe(recipe: Recipe)
     fun updateRecipe(recipe: Recipe)
+    fun deleteRecipe(id: Int)
 }

--- a/app/src/main/java/com/example/app/domain/usecase/DeleteRecipeUseCase.kt
+++ b/app/src/main/java/com/example/app/domain/usecase/DeleteRecipeUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.app.domain.usecase
+
+import com.example.app.domain.repository.RecipeRepository
+
+/**
+ * Deletes a recipe identified by its id.
+ */
+class DeleteRecipeUseCase(private val repository: RecipeRepository) {
+    operator fun invoke(id: Int) = repository.deleteRecipe(id)
+}

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.example.app.R
 import com.example.app.ServiceLocator
 import com.example.app.domain.usecase.GetRecipeUseCase
+import com.example.app.domain.usecase.DeleteRecipeUseCase
 import com.example.app.presentation.add.AddRecipeActivity
 import com.example.app.domain.model.Step
 
@@ -22,9 +23,10 @@ class RecipeDetailActivity : AppCompatActivity() {
     private val viewModel: RecipeDetailViewModel by viewModels {
         object : androidx.lifecycle.ViewModelProvider.Factory {
             override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-                val useCase = GetRecipeUseCase(ServiceLocator.recipeRepository)
+                val get = GetRecipeUseCase(ServiceLocator.recipeRepository)
+                val delete = DeleteRecipeUseCase(ServiceLocator.recipeRepository)
                 @Suppress("UNCHECKED_CAST")
-                return RecipeDetailViewModel(useCase) as T
+                return RecipeDetailViewModel(get, delete) as T
             }
         }
     }
@@ -65,6 +67,11 @@ class RecipeDetailActivity : AppCompatActivity() {
             val intent = Intent(this, AddRecipeActivity::class.java)
             intent.putExtra(AddRecipeActivity.EXTRA_RECIPE_ID, id)
             startActivity(intent)
+        }
+
+        findViewById<Button>(R.id.delete_button).setOnClickListener {
+            viewModel.deleteRecipe(id)
+            finish()
         }
 
         findViewById<Button>(R.id.back_button).setOnClickListener { finish() }

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailViewModel.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailViewModel.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.app.domain.model.Recipe
 import com.example.app.domain.usecase.GetRecipeUseCase
+import com.example.app.domain.usecase.DeleteRecipeUseCase
 
 /**
  * ViewModel for displaying a single recipe.
  */
 class RecipeDetailViewModel(
-    private val getRecipe: GetRecipeUseCase
+    private val getRecipe: GetRecipeUseCase,
+    private val deleteRecipeUseCase: DeleteRecipeUseCase
 ) : ViewModel() {
 
     private val _recipe = MutableLiveData<Recipe>()
@@ -25,5 +27,9 @@ class RecipeDetailViewModel(
      */
     fun updateServings(newServings: Int) {
         _recipe.value = _recipe.value?.copy(servings = newServings)
+    }
+
+    fun deleteRecipe(id: Int) {
+        deleteRecipeUseCase(id)
     }
 }

--- a/app/src/main/res/layout/activity_recipe_detail.xml
+++ b/app/src/main/res/layout/activity_recipe_detail.xml
@@ -54,6 +54,12 @@
             android:text="Edit" />
 
         <Button
+            android:id="@+id/delete_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Delete" />
+
+        <Button
             android:id="@+id/back_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- fix visibility issue in `PersistentRecipeRepository`
- allow recipes to be deleted via new `deleteRecipe()` API
- implement deletion in repositories and add use case
- wire deletion from detail screen and update layout

## Testing
- `./gradlew test --quiet` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686c1f4074908330b162e5db7fc2c365