### PR TITLE
Add predefined unit choices

### DIFF
--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
@@ -233,12 +233,19 @@ class AddRecipeActivity : AppCompatActivity() {
     }
 
     private fun askUnitForIngredient(name: String, onUnit: (String) -> Unit) {
-        val input = EditText(this)
+        val units = arrayOf("ml", "l", "g", "kg", "Stk", "Sonstiges")
+        val displayUnits = arrayOf(
+            "Milliliter (ml)",
+            "Liter (l)",
+            "Gramm (g)",
+            "Kilo (kg)",
+            "Stück (Stk.)",
+            "Sonstiges"
+        )
         AlertDialog.Builder(this)
             .setTitle("Einheit für $name")
-            .setView(input)
-            .setPositiveButton("OK") { _, _ ->
-                onUnit(input.text.toString().trim())
+            .setItems(displayUnits) { _, which ->
+                onUnit(units[which])
             }
             .setCancelable(false)
             .show()


### PR DESCRIPTION
## Summary
- use a predefined list of units during recipe creation

## Testing
- `gradle assembleDebug` *(fails: Calculating task graph)*

------
https://chatgpt.com/codex/tasks/task_e_686eb8c570608330b8cfb498f1cd8098