### PR TITLE
Add ingredient table with case-insensitive names

### DIFF
--- a/app/src/main/java/com/example/app/domain/util/DefaultUnits.kt
+++ b/app/src/main/java/com/example/app/domain/util/DefaultUnits.kt
@@ -17,8 +17,8 @@ val defaultUnits: MutableMap<String, String> = ConcurrentHashMap(
 
 /** Adds or updates the default unit for the given ingredient name. */
 fun setDefaultUnit(name: String, unit: String) {
-    defaultUnits[name] = unit
+    defaultUnits[name.lowercase()] = unit
 }
 
 /** Returns the default unit for the ingredient name, or null if unknown. */
-fun getDefaultUnit(name: String): String? = defaultUnits[name]
+fun getDefaultUnit(name: String): String? = defaultUnits[name.lowercase()]

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -44,7 +44,8 @@ class RecipeDetailActivity : AppCompatActivity() {
             ingredientLayout.removeAllViews()
             recipe.ingredients.forEach { ingredient ->
                 val tv = TextView(this)
-                tv.text = "${ingredient.name}: ${ingredient.quantityPerServing * recipe.servings} ${ingredient.unit}"
+                val amount = (ingredient.quantityPerServing * recipe.servings).toInt()
+                tv.text = "${ingredient.name}: $amount ${ingredient.unit}"
                 ingredientLayout.addView(tv)
             }
 
@@ -83,8 +84,8 @@ class RecipeDetailActivity : AppCompatActivity() {
         var text = step.description
         step.ingredients.forEach { si ->
             val token = "{{${si.ingredient.name}}}"
-            val amount = si.amountPerServing * servings
-            text = text.replace(token, "$amount ${si.ingredient.unit}")
+            val amount = (si.amountPerServing * servings).toInt()
+            text = text.replace(token, "$amount ${si.ingredient.unit}", ignoreCase = true)
         }
         return text
     }

--- a/app/src/main/res/layout/activity_add_recipe.xml
+++ b/app/src/main/res/layout/activity_add_recipe.xml
@@ -33,12 +33,17 @@
             android:layout_height="wrap_content"
             android:text="Select Image" />
 
-        <EditText
-            android:id="@+id/input_ingredients"
+        <TableLayout
+            android:id="@+id/ingredients_table"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Ingredients (name,quantity,unit per line)"
-            android:inputType="textMultiLine" />
+            android:stretchColumns="*" />
+
+        <Button
+            android:id="@+id/button_add_ingredient"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Add Ingredient" />
 
         <EditText
             android:id="@+id/input_steps"


### PR DESCRIPTION
## Summary
- show ingredients in a table on the add recipe screen
- allow editing ingredients from that table
- lookup default units case-insensitively
- treat ingredient tokens case-insensitively and show integer amounts

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686eba52c7d483308505579431e6e0d4