### PR TITLE
Add inline editing to recipe details

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.1")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.1")
 
+    // RecyclerView for lists
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
+
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Permissions for taking and selecting photos -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
         android:name="com.example.app.CookbookApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailViewModel.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailViewModel.kt
@@ -6,13 +6,15 @@ import androidx.lifecycle.ViewModel
 import com.example.app.domain.model.Recipe
 import com.example.app.domain.usecase.GetRecipeUseCase
 import com.example.app.domain.usecase.DeleteRecipeUseCase
+import com.example.app.domain.usecase.UpdateRecipeUseCase
 
 /**
  * ViewModel for displaying a single recipe.
  */
 class RecipeDetailViewModel(
     private val getRecipe: GetRecipeUseCase,
-    private val deleteRecipeUseCase: DeleteRecipeUseCase
+    private val deleteRecipeUseCase: DeleteRecipeUseCase,
+    private val updateRecipeUseCase: UpdateRecipeUseCase
 ) : ViewModel() {
 
     private val _recipe = MutableLiveData<Recipe>()
@@ -31,5 +33,10 @@ class RecipeDetailViewModel(
 
     fun deleteRecipe(id: Int) {
         deleteRecipeUseCase(id)
+    }
+
+    fun updateRecipe(recipe: Recipe) {
+        updateRecipeUseCase(recipe)
+        _recipe.value = recipe
     }
 }

--- a/app/src/main/java/com/example/app/presentation/detail/adapter/IngredientAdapter.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/adapter/IngredientAdapter.kt
@@ -1,0 +1,51 @@
+package com.example.app.presentation.detail.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.app.R
+import com.example.app.domain.model.Ingredient
+
+/** Adapter for displaying ingredients. */
+class IngredientAdapter(
+    private val items: MutableList<Ingredient>,
+    private val onClick: (View, Int, Ingredient) -> Unit
+) : RecyclerView.Adapter<IngredientAdapter.IngredientViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IngredientViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_ingredient, parent, false)
+        return IngredientViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: IngredientViewHolder, position: Int) {
+        val ing = items[position]
+        holder.name.text = ing.name
+        holder.itemView.setOnClickListener { onClick(holder.itemView, position, ing) }
+    }
+
+    fun setItems(list: List<Ingredient>) {
+        items.clear()
+        items.addAll(list)
+        notifyDataSetChanged()
+    }
+
+    fun update(index: Int, ingredient: Ingredient) {
+        items[index] = ingredient
+        notifyItemChanged(index)
+    }
+
+    fun remove(index: Int) {
+        items.removeAt(index)
+        notifyItemRemoved(index)
+    }
+
+    fun getItems(): List<Ingredient> = items.toList()
+
+    class IngredientViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val name: TextView = view.findViewById(R.id.ingredient_name)
+    }
+}

--- a/app/src/main/java/com/example/app/presentation/detail/adapter/StepEditAdapter.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/adapter/StepEditAdapter.kt
@@ -1,0 +1,37 @@
+package com.example.app.presentation.detail.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.app.R
+import com.example.app.domain.model.Step
+
+/** Adapter for editing steps with drag-and-drop support. */
+class StepEditAdapter(private val items: MutableList<Step>) : RecyclerView.Adapter<StepEditAdapter.StepViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StepViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_step, parent, false)
+        return StepViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: StepViewHolder, position: Int) {
+        holder.text.text = items[position].description
+    }
+
+    fun swap(from: Int, to: Int) {
+        if (from == to) return
+        val item = items.removeAt(from)
+        items.add(to, item)
+        notifyItemMoved(from, to)
+    }
+
+    fun getSteps(): List<Step> = items.toList()
+
+    class StepViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val text: TextView = view.findViewById(R.id.step_text)
+    }
+}

--- a/app/src/main/res/layout/activity_recipe_detail.xml
+++ b/app/src/main/res/layout/activity_recipe_detail.xml
@@ -9,10 +9,38 @@
         android:orientation="vertical"
         android:padding="16dp">
 
+        <ImageView
+            android:id="@+id/dish_image"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_gallery" />
+
+        <TextView
+            android:id="@+id/dish_name_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:textSize="20sp" />
+
+        <EditText
+            android:id="@+id/dish_name_edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:visibility="gone" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/edit_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Edit" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:paddingTop="8dp">
 
             <EditText
                 android:id="@+id/servings_input"
@@ -34,24 +62,17 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
-        <LinearLayout
-            android:id="@+id/ingredient_container"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/ingredients_list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical" />
+            android:paddingTop="8dp" />
 
-        <LinearLayout
-            android:id="@+id/step_container"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/steps_list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:paddingTop="16dp" />
-
-        <Button
-            android:id="@+id/edit_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Edit" />
+            android:paddingTop="8dp" />
 
         <Button
             android:id="@+id/delete_button"

--- a/app/src/main/res/layout/item_ingredient.xml
+++ b/app/src/main/res/layout/item_ingredient.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/ingredient_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="16sp" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_step.xml
+++ b/app/src/main/res/layout/item_step.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/step_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="16sp" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add RecyclerView dependency
- declare camera/storage permissions
- overhaul RecipeDetailActivity with edit switch, inline name edit, image picker, ingredient and step lists
- add adapters for ingredients and steps
- update detail ViewModel with updateRecipe
- replace detail layout with new interactive UI

## Testing
- `./gradlew assemble` *(fails: unable to access gradle wrapper jar)*

------
https://chatgpt.com/codex/tasks/task_e_68715bb09130833081de5a53d2f30739