### PR TITLE
Add shopping list navigation

### DIFF
--- a/app/src/main/java/com/example/app/ServiceLocator.kt
+++ b/app/src/main/java/com/example/app/ServiceLocator.kt
@@ -11,6 +11,9 @@ object ServiceLocator {
     private lateinit var applicationContext: Context
     val recipeRepository: RecipeRepository by lazy { PersistentRecipeRepository(applicationContext) }
 
+    /** Last generated shopping list text. */
+    var shoppingList: String = ""
+
     fun init(context: Context) {
         applicationContext = context.applicationContext
     }

--- a/app/src/main/java/com/example/app/presentation/list/MainActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/list/MainActivity.kt
@@ -54,6 +54,11 @@ class MainActivity : AppCompatActivity() {
         findViewById<Button>(R.id.nav_plan).setOnClickListener {
             startActivity(Intent(this, com.example.app.presentation.plan.MealPlanActivity::class.java))
         }
+        findViewById<Button>(R.id.nav_shopping).setOnClickListener {
+            val intent = Intent(this, com.example.app.presentation.plan.ShoppingListActivity::class.java)
+            intent.putExtra(com.example.app.presentation.plan.ShoppingListActivity.EXTRA_LIST, ServiceLocator.shoppingList)
+            startActivity(intent)
+        }
 
         viewModel.recipes.observe(this) { adapter.submitList(it) }
         viewModel.loadRecipes()

--- a/app/src/main/java/com/example/app/presentation/plan/MealPlanActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/plan/MealPlanActivity.kt
@@ -65,6 +65,7 @@ class MealPlanActivity : AppCompatActivity() {
                 }
             }
             val listText = totals.entries.joinToString("\n") { "${it.key}: ${it.value.second} ${it.value.first}" }
+            ServiceLocator.shoppingList = listText
             val intent = Intent(this, ShoppingListActivity::class.java)
             intent.putExtra(ShoppingListActivity.EXTRA_LIST, listText)
             startActivity(intent)
@@ -74,5 +75,10 @@ class MealPlanActivity : AppCompatActivity() {
             startActivity(Intent(this, com.example.app.presentation.list.MainActivity::class.java))
         }
         findViewById<Button>(R.id.nav_plan).setOnClickListener { }
+        findViewById<Button>(R.id.nav_shopping).setOnClickListener {
+            val intent = Intent(this, ShoppingListActivity::class.java)
+            intent.putExtra(ShoppingListActivity.EXTRA_LIST, ServiceLocator.shoppingList)
+            startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/example/app/presentation/plan/ShoppingListActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/plan/ShoppingListActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.example.app.R
+import com.example.app.ServiceLocator
 
 class ShoppingListActivity : AppCompatActivity() {
 
@@ -11,7 +12,7 @@ class ShoppingListActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_shopping_list)
 
-        val text = intent.getStringExtra(EXTRA_LIST) ?: ""
+        val text = intent.getStringExtra(EXTRA_LIST) ?: ServiceLocator.shoppingList
         findViewById<TextView>(R.id.list_text).text = text
     }
 

--- a/app/src/main/res/layout/view_bottom_nav.xml
+++ b/app/src/main/res/layout/view_bottom_nav.xml
@@ -18,4 +18,11 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:text="@string/meal_plan" />
+
+    <Button
+        android:id="@+id/nav_shopping"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="@string/shopping_list" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
     <string name="back">Back</string>
     <string name="recipes">Recipes</string>
     <string name="meal_plan">Meal Plan</string>
+    <string name="shopping_list">Shopping List</string>
 </resources>


### PR DESCRIPTION
## Summary
- store latest shopping list text in `ServiceLocator`
- add a "Shopping List" button to the bottom navigation view
- open the shopping list from both the recipe list and meal plan screens
- keep the generated list accessible via `ServiceLocator`

## Testing
- `./gradlew assemble` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68715dd3376c8330bdfa4587d53373b6