### PR TITLE
Implement inline edit mode and step management

### DIFF
--- a/app/src/main/java/com/example/app/presentation/detail/adapter/StepEditAdapter.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/adapter/StepEditAdapter.kt
@@ -9,7 +9,10 @@ import com.example.app.R
 import com.example.app.domain.model.Step
 
 /** Adapter for editing steps with drag-and-drop support. */
-class StepEditAdapter(private val items: MutableList<Step>) : RecyclerView.Adapter<StepEditAdapter.StepViewHolder>() {
+class StepEditAdapter(
+    private val items: MutableList<Step>,
+    private val onClick: (View, Int, Step) -> Unit
+) : RecyclerView.Adapter<StepEditAdapter.StepViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StepViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_step, parent, false)
@@ -19,7 +22,9 @@ class StepEditAdapter(private val items: MutableList<Step>) : RecyclerView.Adapt
     override fun getItemCount(): Int = items.size
 
     override fun onBindViewHolder(holder: StepViewHolder, position: Int) {
-        holder.text.text = items[position].description
+        val step = items[position]
+        holder.text.text = step.description
+        holder.itemView.setOnClickListener { onClick(holder.itemView, position, step) }
     }
 
     fun swap(from: Int, to: Int) {
@@ -27,6 +32,16 @@ class StepEditAdapter(private val items: MutableList<Step>) : RecyclerView.Adapt
         val item = items.removeAt(from)
         items.add(to, item)
         notifyItemMoved(from, to)
+    }
+
+    fun update(index: Int, step: Step) {
+        items[index] = step
+        notifyItemChanged(index)
+    }
+
+    fun remove(index: Int) {
+        items.removeAt(index)
+        notifyItemRemoved(index)
     }
 
     fun getSteps(): List<Step> = items.toList()

--- a/app/src/main/res/layout/activity_recipe_detail.xml
+++ b/app/src/main/res/layout/activity_recipe_detail.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="16dp">
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
 
         <ImageView
             android:id="@+id/dish_image"
@@ -62,17 +68,38 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/ingredients_list"
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="8dp" />
+            android:layout_marginTop="8dp">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/steps_list"
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/ingredients_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="8dp" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="8dp" />
+            android:layout_marginTop="8dp">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/steps_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="8dp" />
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+    </ScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
 
         <Button
             android:id="@+id/delete_button"
@@ -86,4 +113,4 @@
             android:layout_height="wrap_content"
             android:text="@string/back" />
     </LinearLayout>
-</ScrollView>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- enable inline editing of the recipe name with a toggle and confirmation dialog
- update `StepEditAdapter` to support click actions and modifications
- group ingredients and steps in cards and make delete/back buttons sticky

## Testing
- `./gradlew assembleDebug` *(fails: unable to access gradle wrapper jar)*

------
https://chatgpt.com/codex/tasks/task_e_68715ee82cc48330ab7d509aa812864a