### PR TITLE
Improve recipe editing UI

### DIFF
--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
@@ -82,6 +82,7 @@ class AddRecipeActivity : AppCompatActivity() {
         ingredientsTable = findViewById(R.id.ingredients_table)
 
         stepAdapter = StepAdapter(steps)
+        stepAdapter.showHandles = editMode
         val stepsView = findViewById<RecyclerView>(R.id.steps_list)
         stepsView.adapter = stepAdapter
 
@@ -142,6 +143,8 @@ class AddRecipeActivity : AppCompatActivity() {
             editMode = !editMode
             toggleEdit.text = if (editMode) "Fertig" else "Schritte bearbeiten"
             addStepButton.visibility = if (editMode) View.VISIBLE else View.GONE
+            stepAdapter.showHandles = editMode
+            stepAdapter.notifyDataSetChanged()
         }
 
         addStepButton.setOnClickListener { showStepDialog() }

--- a/app/src/main/java/com/example/app/presentation/add/steps/StepAdapter.kt
+++ b/app/src/main/java/com/example/app/presentation/add/steps/StepAdapter.kt
@@ -12,6 +12,9 @@ import com.example.app.R
  */
 class StepAdapter(private val items: MutableList<String>) : RecyclerView.Adapter<StepAdapter.StepViewHolder>() {
 
+    /** Whether drag handles should be shown. */
+    var showHandles: Boolean = false
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StepViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_step, parent, false)
         return StepViewHolder(view)
@@ -21,6 +24,7 @@ class StepAdapter(private val items: MutableList<String>) : RecyclerView.Adapter
 
     override fun onBindViewHolder(holder: StepViewHolder, position: Int) {
         holder.text.text = "${position + 1}. ${items[position]}"
+        holder.handle.visibility = if (showHandles) View.VISIBLE else View.GONE
     }
 
     fun swap(from: Int, to: Int) {

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -78,6 +78,7 @@ class RecipeDetailActivity : AppCompatActivity() {
         val image = findViewById<ImageView>(R.id.dish_image)
         val ingredientsView = findViewById<RecyclerView>(R.id.ingredients_list)
         val stepsView = findViewById<RecyclerView>(R.id.steps_list)
+        val addStepButton = findViewById<Button>(R.id.add_step_button)
         val editSwitch = findViewById<SwitchCompat>(R.id.edit_switch)
 
         nameView.setOnClickListener {
@@ -97,6 +98,7 @@ class RecipeDetailActivity : AppCompatActivity() {
         stepAdapter = StepEditAdapter(mutableListOf()) { view, index, step ->
             if (editMode) showStepMenu(view, index, step)
         }
+        stepAdapter.showHandles = editMode
         stepsView.layoutManager = LinearLayoutManager(this)
         stepsView.adapter = stepAdapter
 
@@ -114,6 +116,14 @@ class RecipeDetailActivity : AppCompatActivity() {
         })
         itemTouchHelper.attachToRecyclerView(stepsView)
 
+        addStepButton.setOnClickListener {
+            if (editMode) {
+                showStepDialog(Step("", emptyList())) { newStep ->
+                    stepAdapter.addStep(newStep)
+                }
+            }
+        }
+
         viewModel.recipe.observe(this) { recipe ->
             currentRecipe = recipe
             populateFields(recipe)
@@ -130,6 +140,7 @@ class RecipeDetailActivity : AppCompatActivity() {
                 editMode = true
                 nameView.visibility = View.VISIBLE
                 nameEdit.visibility = View.GONE
+                addStepButton.visibility = View.VISIBLE
             } else {
                 editMode = false
                 val recipe = currentRecipe ?: return@setOnCheckedChangeListener
@@ -141,6 +152,7 @@ class RecipeDetailActivity : AppCompatActivity() {
                 )
                 nameView.visibility = View.VISIBLE
                 nameEdit.visibility = View.GONE
+                addStepButton.visibility = View.GONE
                 if (updated != recipe) {
                     android.app.AlertDialog.Builder(this)
                         .setMessage("Save changes?")
@@ -155,6 +167,8 @@ class RecipeDetailActivity : AppCompatActivity() {
                     populateFields(recipe)
                 }
             }
+            stepAdapter.showHandles = editMode
+            stepAdapter.notifyDataSetChanged()
         }
 
         image.setOnClickListener {
@@ -259,6 +273,7 @@ class RecipeDetailActivity : AppCompatActivity() {
         stepAdapter = StepEditAdapter(recipe.steps.toMutableList()) { view, index, step ->
             if (editMode) showStepMenu(view, index, step)
         }
+        stepAdapter.showHandles = editMode
         findViewById<RecyclerView>(R.id.steps_list).adapter = stepAdapter
     }
 

--- a/app/src/main/java/com/example/app/presentation/detail/adapter/IngredientAdapter.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/adapter/IngredientAdapter.kt
@@ -23,7 +23,8 @@ class IngredientAdapter(
 
     override fun onBindViewHolder(holder: IngredientViewHolder, position: Int) {
         val ing = items[position]
-        holder.name.text = ing.name
+        val text = "${ing.quantityPerServing.toInt()} ${ing.unit} ${ing.name}"
+        holder.name.text = text
         holder.itemView.setOnClickListener { onClick(holder.itemView, position, ing) }
     }
 

--- a/app/src/main/java/com/example/app/presentation/detail/adapter/StepEditAdapter.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/adapter/StepEditAdapter.kt
@@ -14,6 +14,9 @@ class StepEditAdapter(
     private val onClick: (View, Int, Step) -> Unit
 ) : RecyclerView.Adapter<StepEditAdapter.StepViewHolder>() {
 
+    /** Whether drag handles should be shown. */
+    var showHandles: Boolean = false
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StepViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_step, parent, false)
         return StepViewHolder(view)
@@ -23,7 +26,8 @@ class StepEditAdapter(
 
     override fun onBindViewHolder(holder: StepViewHolder, position: Int) {
         val step = items[position]
-        holder.text.text = step.description
+        holder.text.text = "${position + 1}. ${step.description}"
+        holder.handle.visibility = if (showHandles) View.VISIBLE else View.GONE
         holder.itemView.setOnClickListener { onClick(holder.itemView, position, step) }
     }
 
@@ -44,9 +48,15 @@ class StepEditAdapter(
         notifyItemRemoved(index)
     }
 
+    fun addStep(step: Step) {
+        items.add(step)
+        notifyItemInserted(items.size - 1)
+    }
+
     fun getSteps(): List<Step> = items.toList()
 
     class StepViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val text: TextView = view.findViewById(R.id.step_text)
+        val handle: View = view.findViewById(R.id.drag_handle)
     }
 }

--- a/app/src/main/res/layout/activity_recipe_detail.xml
+++ b/app/src/main/res/layout/activity_recipe_detail.xml
@@ -68,6 +68,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
+        <TextView
+            android:id="@+id/ingredients_heading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:text="@string/ingredients_heading"
+            android:textStyle="bold" />
+
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -91,6 +99,13 @@
                 android:layout_height="wrap_content"
                 android:padding="8dp" />
         </com.google.android.material.card.MaterialCardView>
+
+        <Button
+            android:id="@+id/add_step_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Add Step"
+            android:visibility="gone" />
 
     </LinearLayout>
     </ScrollView>


### PR DESCRIPTION
## Summary
- add heading over ingredient list
- show quantity and unit before ingredient name
- number steps and add drag handle visibility toggling
- allow adding new steps in detail view

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_687164ed8b548330b3e48d5e72f7be6c