### PR TITLE
Improve image loading resilience

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,9 @@ dependencies {
     // RecyclerView for lists
     implementation("androidx.recyclerview:recyclerview:1.3.2")
 
+    // Asynchronous image loading
+    implementation("com.github.bumptech.glide:glide:4.16.0")
+
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
@@ -22,7 +22,8 @@ import com.example.app.domain.model.StepIngredient
 import com.example.app.presentation.add.steps.StepAdapter
 import com.example.app.domain.util.getDefaultUnit
 import com.example.app.domain.util.setDefaultUnit
-import com.example.app.domain.util.loadScaledBitmap
+import com.bumptech.glide.Glide
+import com.google.android.material.snackbar.Snackbar
 import com.example.app.domain.usecase.AddRecipeUseCase
 import com.example.app.domain.usecase.GetRecipeUseCase
 import com.example.app.domain.usecase.UpdateRecipeUseCase
@@ -64,15 +65,15 @@ class AddRecipeActivity : AppCompatActivity() {
     private val pickImageLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
         uri?.let {
             try {
-                val bmp = loadScaledBitmap(this, it)
                 selectedImageUri = it
-                if (bmp != null) {
-                    findViewById<ImageView>(R.id.image_preview).setImageBitmap(bmp)
-                } else {
-                    findViewById<ImageView>(R.id.image_preview).setImageURI(it)
-                }
+                Glide.with(this)
+                    .load(it)
+                    .placeholder(android.R.drawable.ic_menu_gallery)
+                    .error(android.R.drawable.ic_menu_report_image)
+                    .into(findViewById(R.id.image_preview))
             } catch (e: Exception) {
-                Toast.makeText(this, "Image load failed", Toast.LENGTH_SHORT).show()
+                Snackbar.make(findViewById(android.R.id.content), "Image load failed", Snackbar.LENGTH_LONG).show()
+                findViewById<ImageView>(R.id.image_preview).setImageResource(android.R.drawable.ic_menu_report_image)
             }
         }
     }
@@ -82,9 +83,14 @@ class AddRecipeActivity : AppCompatActivity() {
             try {
                 val uri = MediaStore.Images.Media.insertImage(contentResolver, it, "recipe", null)
                 selectedImageUri = Uri.parse(uri)
-                findViewById<ImageView>(R.id.image_preview).setImageBitmap(it)
+                Glide.with(this)
+                    .load(it)
+                    .placeholder(android.R.drawable.ic_menu_gallery)
+                    .error(android.R.drawable.ic_menu_report_image)
+                    .into(findViewById(R.id.image_preview))
             } catch (e: Exception) {
-                Toast.makeText(this, "Image save failed", Toast.LENGTH_SHORT).show()
+                Snackbar.make(findViewById(android.R.id.content), "Image save failed", Snackbar.LENGTH_LONG).show()
+                findViewById<ImageView>(R.id.image_preview).setImageResource(android.R.drawable.ic_menu_report_image)
             }
         }
     }
@@ -129,7 +135,11 @@ class AddRecipeActivity : AppCompatActivity() {
             stepAdapter.notifyDataSetChanged()
             recipe.imageUri?.let { uriStr ->
                 selectedImageUri = Uri.parse(uriStr)
-                findViewById<ImageView>(R.id.image_preview).setImageURI(selectedImageUri)
+                Glide.with(this)
+                    .load(selectedImageUri)
+                    .placeholder(android.R.drawable.ic_menu_gallery)
+                    .error(android.R.drawable.ic_menu_report_image)
+                    .into(findViewById(R.id.image_preview))
             }
         } ?: startWizard()
 

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -26,7 +26,8 @@ import com.example.app.domain.model.Ingredient
 import com.example.app.domain.model.Recipe
 import com.example.app.presentation.detail.adapter.IngredientAdapter
 import com.example.app.presentation.detail.adapter.StepEditAdapter
-import com.example.app.domain.util.loadScaledBitmap
+import com.bumptech.glide.Glide
+import com.google.android.material.snackbar.Snackbar
 
 /**
  * Displays details for a selected recipe.
@@ -56,15 +57,15 @@ class RecipeDetailActivity : AppCompatActivity() {
     private val pickImageLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
         uri?.let {
             try {
-                val bmp = loadScaledBitmap(this, it)
                 selectedImageUri = it
-                if (bmp != null) {
-                    findViewById<ImageView>(R.id.dish_image).setImageBitmap(bmp)
-                } else {
-                    findViewById<ImageView>(R.id.dish_image).setImageURI(it)
-                }
+                Glide.with(this)
+                    .load(it)
+                    .placeholder(android.R.drawable.ic_menu_gallery)
+                    .error(android.R.drawable.ic_menu_report_image)
+                    .into(findViewById(R.id.dish_image))
             } catch (e: Exception) {
-                Toast.makeText(this, "Image load failed", Toast.LENGTH_SHORT).show()
+                Snackbar.make(findViewById(android.R.id.content), "Image load failed", Snackbar.LENGTH_LONG).show()
+                findViewById<ImageView>(R.id.dish_image).setImageResource(android.R.drawable.ic_menu_report_image)
             }
         }
     }
@@ -74,9 +75,14 @@ class RecipeDetailActivity : AppCompatActivity() {
             try {
                 val uri = MediaStore.Images.Media.insertImage(contentResolver, it, "recipe", null)
                 selectedImageUri = Uri.parse(uri)
-                findViewById<ImageView>(R.id.dish_image).setImageBitmap(it)
+                Glide.with(this)
+                    .load(it)
+                    .placeholder(android.R.drawable.ic_menu_gallery)
+                    .error(android.R.drawable.ic_menu_report_image)
+                    .into(findViewById(R.id.dish_image))
             } catch (e: Exception) {
-                Toast.makeText(this, "Image save failed", Toast.LENGTH_SHORT).show()
+                Snackbar.make(findViewById(android.R.id.content), "Image save failed", Snackbar.LENGTH_LONG).show()
+                findViewById<ImageView>(R.id.dish_image).setImageResource(android.R.drawable.ic_menu_report_image)
             }
         }
     }
@@ -280,7 +286,11 @@ class RecipeDetailActivity : AppCompatActivity() {
         nameView.text = recipe.name
         nameEdit.setText(recipe.name)
         selectedImageUri = recipe.imageUri?.let { Uri.parse(it) }
-        if (selectedImageUri != null) image.setImageURI(selectedImageUri) else image.setImageResource(recipe.imageRes)
+        Glide.with(this)
+            .load(selectedImageUri ?: recipe.imageRes)
+            .placeholder(recipe.imageRes)
+            .error(android.R.drawable.ic_menu_report_image)
+            .into(image)
 
         findViewById<TextView>(R.id.servings_value).text = recipe.servings.toString()
         ingredientAdapter.setItems(recipe.ingredients)

--- a/app/src/main/java/com/example/app/presentation/list/RecipeListAdapter.kt
+++ b/app/src/main/java/com/example/app/presentation/list/RecipeListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import com.bumptech.glide.Glide
 import androidx.recyclerview.widget.RecyclerView
 import com.example.app.R
 import com.example.app.domain.model.Recipe
@@ -45,11 +46,12 @@ class RecipeListAdapter(
 
         fun bind(recipe: Recipe) {
             name.text = recipe.name
-            if (recipe.imageUri != null) {
-                image.setImageURI(android.net.Uri.parse(recipe.imageUri))
-            } else {
-                image.setImageResource(recipe.imageRes)
-            }
+            val source = recipe.imageUri ?: recipe.imageRes
+            Glide.with(image.context)
+                .load(source)
+                .placeholder(recipe.imageRes)
+                .error(android.R.drawable.ic_menu_report_image)
+                .into(image)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Glide dependency
- use Glide to asynchronously load images in AddRecipeActivity, RecipeDetailActivity and RecipeListAdapter
- show Snackbar and use placeholders on gallery/camera image errors

## Testing
- `./gradlew assemble` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6871696d821483308b3f4f455e79975a