### PR TITLE
Fix FileProvider authority

### DIFF
--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
@@ -16,7 +16,6 @@ import androidx.activity.viewModels
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import com.example.app.R
-import com.example.app.BuildConfig
 import com.example.app.ServiceLocator
 import com.example.app.domain.model.Ingredient
 import com.example.app.domain.model.Recipe
@@ -108,7 +107,7 @@ class AddRecipeActivity : AppCompatActivity() {
 
     private fun openCamera() {
         val file = java.io.File.createTempFile("recipe_", ".jpg", cacheDir)
-        photoUri = FileProvider.getUriForFile(this, "${BuildConfig.APPLICATION_ID}.fileprovider", file)
+        photoUri = FileProvider.getUriForFile(this, "${applicationContext.packageName}.fileprovider", file)
         takePhotoLauncher.launch(photoUri)
     }
 

--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -30,7 +30,6 @@ import com.example.app.presentation.detail.adapter.IngredientAdapter
 import com.example.app.presentation.detail.adapter.StepEditAdapter
 import com.bumptech.glide.Glide
 import com.google.android.material.snackbar.Snackbar
-import com.example.app.BuildConfig
 
 /**
  * Displays details for a selected recipe.
@@ -100,7 +99,7 @@ class RecipeDetailActivity : AppCompatActivity() {
 
     private fun openCamera() {
         val file = java.io.File.createTempFile("recipe_", ".jpg", cacheDir)
-        photoUri = FileProvider.getUriForFile(this, "${BuildConfig.APPLICATION_ID}.fileprovider", file)
+        photoUri = FileProvider.getUriForFile(this, "${applicationContext.packageName}.fileprovider", file)
         takePhotoLauncher.launch(photoUri)
     }
 


### PR DESCRIPTION
## Summary
- avoid `BuildConfig` in activities by using runtime `packageName`

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68716d25887c833095c99c1521095694