### PR TITLE
Fix nullability issue when launching camera

### DIFF
--- a/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/add/AddRecipeActivity.kt
@@ -107,8 +107,9 @@ class AddRecipeActivity : AppCompatActivity() {
 
     private fun openCamera() {
         val file = java.io.File.createTempFile("recipe_", ".jpg", cacheDir)
-        photoUri = FileProvider.getUriForFile(this, "${applicationContext.packageName}.fileprovider", file)
-        takePhotoLauncher.launch(photoUri)
+        val uri = FileProvider.getUriForFile(this, "${applicationContext.packageName}.fileprovider", file)
+        photoUri = uri
+        takePhotoLauncher.launch(uri)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Summary
- fix compile error around camera URI in `AddRecipeActivity`

## Testing
- `./gradlew assemble` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68716e13d84c83308ed524febb3dc969