### PR TITLE
Implement camera URI handling fixes

### DIFF
--- a/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/detail/RecipeDetailActivity.kt
@@ -99,8 +99,13 @@ class RecipeDetailActivity : AppCompatActivity() {
 
     private fun openCamera() {
         val file = java.io.File.createTempFile("recipe_", ".jpg", cacheDir)
-        photoUri = FileProvider.getUriForFile(this, "${applicationContext.packageName}.fileprovider", file)
-        takePhotoLauncher.launch(photoUri)
+        val uri = FileProvider.getUriForFile(
+            this,
+            "${applicationContext.packageName}.fileprovider",
+            file
+        )
+        photoUri = uri
+        takePhotoLauncher.launch(uri)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Summary
- avoid crash on take photo by keeping URI locally in RecipeDetailActivity

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68716f5290e08330b2c52c8904733bc6