### PR TITLE
Add fragment-ktx dependency and synchronize nav button state

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 
     // Needed for the viewModels activity-ktx extension
     implementation("androidx.activity:activity-ktx:1.9.0")
+    implementation("androidx.fragment:fragment-ktx:1.6.2")
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.1")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.1")

--- a/app/src/main/java/com/example/app/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/home/HomeActivity.kt
@@ -34,6 +34,7 @@ class HomeActivity : AppCompatActivity() {
 
     fun setCurrentPage(index: Int, smooth: Boolean = true) {
         viewPager.setCurrentItem(index, smooth)
+        updateNavButtons(index)
     }
 
     private fun updateNavButtons(index: Int) {


### PR DESCRIPTION
## Summary
- keep the three navigation buttons in `view_bottom_nav`
- ensure swipe animation via `setCurrentItem()` highlights the current nav button
- add `fragment-ktx` dependency required for the `viewModels` delegate

## Testing
- `gradle wrapper` *(fails: Plugin not found due to lack of network)*

------
https://chatgpt.com/codex/tasks/task_e_68717291ece48330b2750dfcc4fff287