### PR TITLE
Fix missing EXTRA_LIST reference

### DIFF
--- a/app/src/main/java/com/example/app/presentation/plan/ShoppingListActivity.kt
+++ b/app/src/main/java/com/example/app/presentation/plan/ShoppingListActivity.kt
@@ -17,6 +17,10 @@ import com.example.app.presentation.plan.adapter.ShoppingAdapter
  */
 class ShoppingListActivity : AppCompatActivity() {
 
+    companion object {
+        const val EXTRA_LIST = "shopping_list"
+    }
+
     private val items = mutableListOf<ShoppingItem>()
     private val recent = mutableListOf<ShoppingItem>()
 


### PR DESCRIPTION
## Summary
- add missing EXTRA_LIST constant in ShoppingListActivity

## Testing
- `./gradlew test` *(fails: unable to access gradle wrapper jar)*

------
https://chatgpt.com/codex/tasks/task_e_68717593fa2c83309b5e08b7c9862216